### PR TITLE
T167 Add interactivity to atom's terminal/T158 Open connection to Cortex

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -66,7 +66,7 @@ module.exports=
   uploadInTerminal: (args...) ->
     return utils.executeInTerminal @upload args...
 
-  cortexInTerminal: (args...) ->
+  serialInTerminal: (args...) ->
     return utils.executeInTerminal @terminal args...
 
   # wrapper function for scoping reasons

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -42,7 +42,6 @@ module.exports=
     return JSON.parse e for e in utils.executeSync(command).split(/\r?\n/)
     .filter(Boolean)
 
-
   getTemplates: (cb, args...) ->
     @executeParsed cb, @lstemplate(args...), {}
 
@@ -69,3 +68,7 @@ module.exports=
 
   cortexInTerminal: (args...) ->
     return utils.executeInTerminal @terminal args...
+
+  # wrapper function for scoping reasons
+  runInTerminal: (command) ->
+    return utils.executeInTerminal command.split ' '

--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -26,6 +26,9 @@ module.exports=
   upload: (args...) ->
     return @baseCommand().concat(['flash'].concat(args...))
 
+  terminal: (args...) ->
+    return @baseCommand().concat(['terminal'].concat(args...))
+
   executeParsed: (cb, command, params) ->
     if '--machine-output' not in command
       command.push '--machine-output'
@@ -63,3 +66,6 @@ module.exports=
 
   uploadInTerminal: (args...) ->
     return utils.executeInTerminal @upload args...
+
+  cortexInTerminal: (args...) ->
+    return utils.executeInTerminal @terminal args...

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -32,6 +32,8 @@ module.exports =
 
       @terminalViewProvider = TerminalView.register
       @terminalViewPanel = new TerminalView
+      @terminalViewPanel.emitter.on 'stdin',
+        (command) -> if command isnt '' then cli.runInTerminal command
 
       # atom.commands.add 'atom-work  space',
       #   'PROS:Toggle-PROS': => @togglePROS()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,7 +5,7 @@
 {Disposable} = require 'atom'
 fs = require 'fs'
 cli = require './cli'
-{consumeDisplayConsole} = require './terminal-utilities'
+terminal = require './terminal-utilities'
 {provideBuilder} = require './make'
 lint = require './lint'
 config = require './config'
@@ -30,13 +30,6 @@ module.exports =
       @upgradeProjectViewProvider = UpgradeProjectView.register
       @upgradeProjectPanel = new UpgradeProjectView
 
-      @terminalViewProvider = TerminalView.register
-      @terminalViewPanel = new TerminalView
-      @terminalViewPanel.emitter.on 'stdin',
-        (command) -> if command isnt '' then cli.runInTerminal command
-
-      # atom.commands.add 'atom-work  space',
-      #   'PROS:Toggle-PROS': => @togglePROS()
       atom.commands.add 'atom-workspace',
         'PROS:New-Project': => @newProject()
       atom.commands.add 'atom-workspace',
@@ -54,10 +47,9 @@ module.exports =
       cli.execute(((c, o) -> console.log o),
         cli.baseCommand().concat ['conduct', 'first-run', '--no-force', '--use-defaults'])
 
-      @terminalViewPanel.toggle()
-      @terminalViewPanel.toggle()
-
   consumeLinter: lint.consumeLinter
+  consumeRunInTerminal: (service) ->
+    terminal.consumeRunInTerminal service
 
   uploadProject: ->
     if atom.project.getPaths().length > 0
@@ -74,48 +66,20 @@ module.exports =
   upgradeProject: ->
     @upgradeProjectPanel.toggle()
 
-  toggleTerminal: ->
-    @terminalViewPanel.toggle()
-
-  openCortex: ->
-    cli.cortexInTerminal()
+  toggleTerminal: -> cli.serialInTerminal()
 
   consumeToolbar: (getToolBar) ->
     @toolBar = getToolBar('pros')
 
-    # @toolBar.addButton {
-    #   icon: 'folder-add',
-    #   callback: 'PROS:New-Project',
-    #   tooltip: 'Create a new PROS Project',
-    #   iconset: 'fi'
-    # }
     @toolBar.addButton {
       icon: 'upload',
       callback: 'PROS:Upload-Project'
       tooltip: 'Upload PROS project',
       iconset: 'fi'
     }
-    # @toolBar.addButton {
-    #   icon: 'check',
-    #   callback: 'PROS:Register-Project',
-    #   tooltip: 'Register PROS project',
-    #   iconset: 'fi'
-    # }
-    # @toolBar.addButton {
-    #   icon: 'arrow-circle-up',
-    #   callback: 'PROS:Upgrade-Project',
-    #   tooltip: 'Upgrade existing PROS project',
-    #   iconset: 'fa'
-    # }
-    @toolBar.addButton {
-      icon: 'eye-slash',
-      callback: 'PROS:Toggle-Terminal',
-      tooltip: 'Toggle PROS terminal output visibility'
-      iconset: 'fa'
-    }
     @toolBar.addButton {
       icon: 'circuit-board',
-      callback: 'PROS:Open-Cortex',
+      callback: 'PROS:Toggle-Terminal',
       tooltip: 'Open cortex serial output'
     }
 
@@ -124,7 +88,7 @@ module.exports =
   autocompleteProvider: ->
     autocomplete.provide()
 
-  consumeStatusBar: ->
-
+  consumeStatusBar: (statusbar) ->
+    terminal.statusBar = statusbar
 
   config: universalConfig.filterConfig config.config, 'atom'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -45,6 +45,9 @@ module.exports =
         'PROS:Upload-Project': => @uploadProject()
       atom.commands.add 'atom-workspace',
         'PROS:Toggle-Terminal': => @toggleTerminal()
+      # name subject to change, this just seems the most descriptive
+      atom.commands.add 'atom-workspace',
+        'PROS:Open-Cortex': => @openCortex()
 
       cli.execute(((c, o) -> console.log o),
         cli.baseCommand().concat ['conduct', 'first-run', '--no-force', '--use-defaults'])
@@ -71,6 +74,9 @@ module.exports =
 
   toggleTerminal: ->
     @terminalViewPanel.toggle()
+
+  openCortex: ->
+    cli.cortexInTerminal()
 
   consumeToolbar: (getToolBar) ->
     @toolBar = getToolBar('pros')
@@ -104,6 +110,11 @@ module.exports =
       callback: 'PROS:Toggle-Terminal',
       tooltip: 'Toggle PROS terminal output visibility'
       iconset: 'fa'
+    }
+    @toolBar.addButton {
+      icon: 'circuit-board',
+      callback: 'PROS:Open-Cortex',
+      tooltip: 'Open cortex serial output'
     }
 
     @toolBar.onDidDestroy => @toolBar = null

--- a/lib/terminal-utilities.coffee
+++ b/lib/terminal-utilities.coffee
@@ -54,6 +54,5 @@ module.exports =
         @createDiv "#{data}", "pros-terminal-stderr"
 
     proc = @execute(cb, command, { includeStdErr: true, onstdout: out, onstderr: err })
-    console.log terminal.cancelBtn
     terminal.cancelBtn.onclick = ->
       proc.kill 'SIGINT'

--- a/lib/terminal-utilities.coffee
+++ b/lib/terminal-utilities.coffee
@@ -44,7 +44,7 @@ module.exports =
 
     cb = (c, o) =>
       terminal.appendOutput \
-        @createDiv "Process exited with code #{c}", "pros-terminal-terminus"
+        @createDiv "Process exited with code #{c ? 0}", "pros-terminal-terminus"
 
     out = (data) ->
       terminal.appendOutput "#{data}"
@@ -53,4 +53,7 @@ module.exports =
       terminal.appendOutput \
         @createDiv "#{data}", "pros-terminal-stderr"
 
-    @execute(cb, command, { includeStdErr: true, onstdout: out, onstderr: err })
+    proc = @execute(cb, command, { includeStdErr: true, onstdout: out, onstderr: err })
+    console.log terminal.cancelBtn
+    terminal.cancelBtn.onclick = ->
+      proc.kill 'SIGINT'

--- a/lib/terminal-utilities.coffee
+++ b/lib/terminal-utilities.coffee
@@ -39,19 +39,24 @@ module.exports =
     return proc.stdout.read()
 
   executeInTerminal: (command) ->
+    wait = (ms) ->
+      start = new Date().getTime()
+      for num in [0...1e7]
+        if ((new Date().getTime() - start) > ms)
+          break
     if Boolean(terminalService)
       if Boolean currentTerminal
         currentTerminal.insertSelection '\x03'
-        currentTerminal.insertSelection if navigator.platform is 'Win32' then 'cls' else 'clear'
-        # Run clear twice in case there wasn't a command running previously.
-        # Interrupt control character will screw the first clear
-        currentTerminal.insertSelection if navigator.platform is 'Win32' then 'cls' else 'clear'
+        wait 75 # hard code waits to allow commands to be executed
+        currentTerminal.insertSelection(if navigator.platform is 'Win32' then 'cls' else 'clear')
+        wait 75
         currentTerminal.insertSelection command.join ' '
         currentTerminal.focus()
       else
         currentTerminal = terminalService.run([command.join ' '])[0].spacePenView
         currentTerminal.statusIcon.style.color = '#cca352'
         currentTerminal.statusIcon.updateName 'PROS CLI'
+        currentTerminal.panel.onDidDestroy () -> currentTerminal = null
       return currentTerminal
     else
       return null

--- a/lib/terminal-utilities.coffee
+++ b/lib/terminal-utilities.coffee
@@ -4,9 +4,9 @@ cp = require 'child_process'
 
 terminalService = null
 currentTerminal = null
+
 module.exports =
-  statusBar: null
-  consumeRunInTerminal: (service) =>
+  consumeRunInTerminal: (service) ->
     if Boolean terminalService
       return new Disposable () -> return
     terminalService = service
@@ -39,10 +39,12 @@ module.exports =
     return proc.stdout.read()
 
   executeInTerminal: (command) ->
-    # terminalService.destroyTerminalView currentTerminal
     if Boolean(terminalService)
       if Boolean currentTerminal
         currentTerminal.insertSelection '\x03'
+        currentTerminal.insertSelection if navigator.platform is 'Win32' then 'cls' else 'clear'
+        # Run clear twice in case there wasn't a command running previously.
+        # Interrupt control character will screw the first clear
         currentTerminal.insertSelection if navigator.platform is 'Win32' then 'cls' else 'clear'
         currentTerminal.insertSelection command.join ' '
         currentTerminal.focus()

--- a/lib/views/terminal/terminal-view.coffee
+++ b/lib/views/terminal/terminal-view.coffee
@@ -9,7 +9,6 @@ module.exports =
       @hideBtn = @element.querySelector '#pros-terminal-hide'
       @hideBtn.onclick = => @hide()
       @cancelBtn = @element.querySelector '#pros-terminal-cancel-command'
-      @cancelBtn.onclick = => @cancelCmd()
       @clearBtn = @element.querySelector '#pros-terminal-clear-output'
       @clearBtn.onclick = => @clearOutput()
 
@@ -22,7 +21,6 @@ module.exports =
       out.innerHTML = @output
       out.scrollTop = out.scrollHeight
 
-
     appendOutput: (data) =>
       @output += data
       @updateOutput()
@@ -30,9 +28,6 @@ module.exports =
     clearOutput: =>
       @output = ''
       @updateOutput()
-
-    cancelCmd: ->
-      # TODO: add ability to cancel command
 
     isVisible: =>
       @panel.isVisible()

--- a/lib/views/terminal/terminal-view.coffee
+++ b/lib/views/terminal/terminal-view.coffee
@@ -11,6 +11,7 @@ module.exports =
       @cancelBtn = @element.querySelector '#pros-terminal-cancel-command'
       @clearBtn = @element.querySelector '#pros-terminal-clear-output'
       @clearBtn.onclick = => @clearOutput()
+      @element.querySelector '.output'
 
     show: =>
       @panel ?= atom.workspace.addBottomPanel className: 'PROSTerminal', item: this

--- a/lib/views/terminal/terminal-view.coffee
+++ b/lib/views/terminal/terminal-view.coffee
@@ -8,6 +8,8 @@ module.exports =
       @output = ''
       @hideBtn = @element.querySelector '#pros-terminal-hide'
       @hideBtn.onclick = => @hide()
+      @cancelBtn = @element.querySelector '#pros-terminal-cancel-command'
+      @cancelBtn.onclick = => @cancelCmd()
       @clearBtn = @element.querySelector '#pros-terminal-clear-output'
       @clearBtn.onclick = => @clearOutput()
 
@@ -16,7 +18,10 @@ module.exports =
       @panel.show()
 
     updateOutput: =>
-      @element.querySelector('.output').innerHTML = @output
+      out = @element.querySelector '.panel-container'
+      out.innerHTML = @output
+      out.scrollTop = out.scrollHeight
+
 
     appendOutput: (data) =>
       @output += data
@@ -25,6 +30,9 @@ module.exports =
     clearOutput: =>
       @output = ''
       @updateOutput()
+
+    cancelCmd: ->
+      # TODO: add ability to cancel command
 
     isVisible: =>
       @panel.isVisible()

--- a/lib/views/terminal/terminal-view.coffee
+++ b/lib/views/terminal/terminal-view.coffee
@@ -1,5 +1,6 @@
 {BaseView, View} = require '../base-view'
 {Emitter} = require 'event-kit'
+cp = require 'child_process'
 
 module.exports =
   TerminalView: class TerminalView extends BaseView
@@ -17,13 +18,13 @@ module.exports =
       @inputField = @element.querySelector '#stdin'
       @inputField.onkeypress = (event) =>
         switch event.which
-          when 13
+          when 13 # handle enter key
             event.preventDefault()
             @emitter.emit 'stdin', @inputField.value
             @history.push @inputField.value
             @inputField.value = ''
             @up = 1
-      @inputField.onkeydown = (event) =>
+      @inputField.onkeydown = (event) => # handle up/down keys
         switch event.which
           when 38
             event.preventDefault()
@@ -60,3 +61,42 @@ module.exports =
 
     register: ->
       super()
+
+    createDiv: (text, classes) ->
+      "<div class=\"#{classes}\">#{text}</div>"
+
+    execute: (command) =>
+      # console.log execute
+      @clearOutput()
+      @appendOutput \
+        @createDiv "#&gt; #{command.join ' '}", "pros-terminal-command"
+
+
+      cb = (c, o) =>
+        @appendOutput \
+          @createDiv "Process exited with code #{c ? 0}", "pros-terminal-terminus"
+
+      out = (data) =>
+        @appendOutput "#{data}"
+
+      err = (data) =>
+        @appendOutput \
+              @createDiv "#{data}", "pros-terminal-stderr"
+
+      outBuf = ''
+      cmd = ''
+      if navigator.platform != 'Win32'
+        cmd = cmd.concat "export LC_ALL=en_US.utf-8;export LANG=en_US.utf-8;"
+      cmd = cmd.concat command.join ' '
+      proc = cp.exec cmd, { 'encoding': 'utf-8' }
+      proc.stderr.on 'data', (data) -> err data
+      proc.stdout.on 'data', (data) ->
+        outBuf += data
+        out data
+      proc.on 'exit', (c, o, e) ->
+        cb c, outBuf
+
+      if not @isVisible() then @toggle()
+      @cancelBtn.onclick = =>
+        console.log "Killing #{command.join ' '}"
+        proc.stdin.end('\x1b\n')

--- a/lib/views/terminal/terminal-view.coffee
+++ b/lib/views/terminal/terminal-view.coffee
@@ -1,17 +1,42 @@
 {BaseView, View} = require '../base-view'
+{Emitter} = require 'event-kit'
 
 module.exports =
   TerminalView: class TerminalView extends BaseView
     constructor: ->
       super(__dirname)
-
+      @emitter = new Emitter
       @output = ''
+      @history = []
+      @up = 1
       @hideBtn = @element.querySelector '#pros-terminal-hide'
       @hideBtn.onclick = => @hide()
       @cancelBtn = @element.querySelector '#pros-terminal-cancel-command'
       @clearBtn = @element.querySelector '#pros-terminal-clear-output'
       @clearBtn.onclick = => @clearOutput()
-      @element.querySelector '.output'
+      @inputField = @element.querySelector '#stdin'
+      @inputField.onkeypress = (event) =>
+        switch event.which
+          when 13
+            event.preventDefault()
+            @emitter.emit 'stdin', @inputField.value
+            @history.push @inputField.value
+            @inputField.value = ''
+            @up = 1
+      @inputField.onkeydown = (event) =>
+        switch event.which
+          when 38
+            event.preventDefault()
+            if @history.length >= 1
+              @inputField.value = @history[@history.length - @up]
+              unless @up + 1 > @history.length
+                @up++
+          when 40
+            event.preventDefault()
+            if @history.length >= 1
+              @inputField.value = @history[@history.length - @up]
+              unless @up - 1 < 0
+                @up--
 
     show: =>
       @panel ?= atom.workspace.addBottomPanel className: 'PROSTerminal', item: this

--- a/lib/views/terminal/view.html
+++ b/lib/views/terminal/view.html
@@ -2,9 +2,10 @@
   <div class="heading" outlet: "panelHeading">
     <div class="control-container opaque-hover">
       <button id="pros-terminal-clear-output" class="btn btn-default icon icon-trashcan"></button>
+      <button id="pros-terminal-cancel-command" class="btn btn-default icon icon-circle-slash"></button>
       <button id="pros-terminal-hide" class="btn btn-default icon icon-x"></button>
     </div>
     <div class="title">PROS Terminal</div>
   </div>
-  <pre class="output panel-body" outlet="output"></pre>
+  <pre class="output panel-body" outlet="output"><div class="output panel-container"></pre>
 </div>

--- a/lib/views/terminal/view.html
+++ b/lib/views/terminal/view.html
@@ -7,5 +7,5 @@
     </div>
     <div class="title">PROS Terminal</div>
   </div>
-  <pre class="output panel-body" outlet="output"><div class="output panel-container"></pre>
+  <pre class="output panel-body" outlet="output"><div class="output panel-container"><div></pre>
 </div>

--- a/lib/views/terminal/view.html
+++ b/lib/views/terminal/view.html
@@ -7,5 +7,9 @@
     </div>
     <div class="title">PROS Terminal</div>
   </div>
-  <pre class="output panel-body" outlet="output"><div class="output panel-container"><div></pre>
+  <pre class="output panel-body" outlet="output"><div class="output panel-container"></div></pre>
+  <div class="input">
+    <label class="PS1" for="stdin"># &gt;</label>
+    <input id="stdin" class="text" type="text" />
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "atom-package-deps": "^4.0.0",
     "clang-flags": "0.2.2",
     "command-exists": "^1.0.0",
+    "event-kit": "^2.1.0",
     "fs-extra": "^0.26.1",
     "split-string": "^0.1.0",
     "tempfile": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "linter",
     "tool-bar",
     "tool-bar-main",
-    "build"
+    "build",
+    "platformio-ide-terminal"
   ],
   "consumedServices": {
     "tool-bar": {
@@ -48,6 +49,11 @@
     "status-bar": {
       "versions": {
         "1.0.0": "consumeStatusBar"
+      }
+    },
+    "runInTerminal": {
+      "versions": {
+        "^0.14.0": "consumeRunInTerminal"
       }
     }
   },

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -27,6 +27,7 @@ atom-panel.bottom .pros-terminal {
     font-size: 1.1em;
     background-color: #000;
     font-family: monospace;
+    overflow: auto;
     .pros-terminal-command {
       font-style: italic;
     }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -5,10 +5,12 @@ atom-panel.bottom .pros-terminal {
     -webkit-user-select: none;
     line-height: 3.0em;
     padding: 0 3px;
+    margin: 0 0 1em 1em;
 
     .control-container {
       float: right;
       margin-left: @component-padding;
+      clear: right;
 
       .btn {
         color: @text-color-info;
@@ -20,6 +22,9 @@ atom-panel.bottom .pros-terminal {
       }
     }
   }
+  pre .output {
+    margin: auto;
+  }
 
   .output {
     height: 300px;
@@ -28,6 +33,8 @@ atom-panel.bottom .pros-terminal {
     background-color: #000;
     font-family: monospace;
     overflow: auto;
+    margin: auto;
+
     .pros-terminal-command {
       font-style: italic;
     }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -24,6 +24,7 @@ atom-panel.bottom .pros-terminal {
   }
   pre .output {
     margin: auto;
+    padding-left: 5px;
   }
 
   .output {
@@ -48,6 +49,35 @@ atom-panel.bottom .pros-terminal {
     //   padding: 20px;
     //   font-family: monospace;
     // }
+  }
+}
+
+.input {
+  width: 100%;
+  padding: 3px;
+  padding-left: 0;
+  padding-right: 10px;
+  font-family: monospace;
+  display: inline-flex;
+  .PS1 {
+    float: left;
+    height: 100%;
+    flex-grow: 0;
+    padding: 10px;
+    margin: 0;
+    background-color: #000;
+    border-radius: 5px 0 0 5px;
+  }
+  .text {
+    //width: 100%;
+    flex-grow: 15;
+    float: right;
+    color: #fff;
+    background-color: #000;
+    border-style: none;
+    border-radius: 0 5px 5px 0;
+    overflow-x: scroll; // In case the command is way too long
+    padding-left: 5px;
   }
 }
 


### PR DESCRIPTION
The terminal now has a text box that will accept input and run it as a shell command when the user presses enter. The user can also traverse their command history by using the up/down arrow keys.

Added a new command that allows users to view Cortex output in the terminal as long as the Cortex is connected over serial (wrapper for `pros terminal`).

Also added a method to kill commands by sending a `SIGINT` to the threads running them. ([related](https://github.com/purduesigbots/pros-cli/pull/14))