### PR TITLE
Add better root project directory discovery (try to find project.pros)

### DIFF
--- a/lib/autocomplete/clang-provider.coffee
+++ b/lib/autocomplete/clang-provider.coffee
@@ -7,6 +7,7 @@ path = require 'path'
 {existsSync} = require 'fs'
 ClangFlags = require 'clang-flags'
 config = require '../config'
+utils = require '../utils'
 
 module.exports =
 class ClangProvider
@@ -38,15 +39,15 @@ class ClangProvider
     command = 'clang'
     args = @buildClangArgs(editor, row, column, language)
     options =
-      cwd: atom.project.getPaths().filter((project) -> ~atom.workspace.getActiveTextEditor().getPath().indexOf project)?[0]
+      cwd: utils.getRoot atom.workspace.getActiveTextEditor().getPath()
       input: editor.getText()
     new Promise (resolve) =>
       allOutput = []
-      stdout = (output) => allOutput.push(output)
-      stderr = (output) => console.log output
+      stdout = (output) -> allOutput.push output
+      stderr = (output) -> console.log output
       exit = (code) => resolve(@handleCompletionResult(allOutput.join('\n'), code, prefix))
       bufferedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})
-      bufferedProcess.process.stdin.setEncoding = 'utf-8';
+      bufferedProcess.process.stdin.setEncoding = 'utf-8'
       bufferedProcess.process.stdin.write(editor.getText())
       bufferedProcess.process.stdin.end()
 
@@ -93,9 +94,9 @@ class ClangProvider
     outputLines = result.match(completionsRe)
 
     if outputLines?
-        return (@convertCompletionLine(line, prefix) for line in outputLines)
+      return (@convertCompletionLine(line, prefix) for line in outputLines)
     else
-        return []
+      return []
 
   buildClangArgs: (editor, row, column, language) ->
     settings = config.settings()

--- a/lib/autocomplete/clang-provider.coffee
+++ b/lib/autocomplete/clang-provider.coffee
@@ -39,7 +39,7 @@ class ClangProvider
     command = 'clang'
     args = @buildClangArgs(editor, row, column, language)
     options =
-      cwd: utils.getRoot atom.workspace.getActiveTextEditor().getPath()
+      cwd: utils.findRoot atom.workspace.getActiveTextEditor().getPath()
       input: editor.getText()
     new Promise (resolve) =>
       allOutput = []

--- a/lib/lint.coffee
+++ b/lib/lint.coffee
@@ -5,6 +5,7 @@ fs = require 'fs'
 linthelp = require 'atom-linter'
 path = require 'path'
 terminal = require './terminal-utilities'
+utils = require './utils'
 
 module.exports =
   messages: {}
@@ -24,11 +25,7 @@ module.exports =
     else undefined
 
   lint: (editor, lintable_file, real_file) ->
-    cwd = ''
-    current_path = atom.workspace.getActiveTextEditor().getPath()
-    for project in atom.project.getPaths()
-      if current_path.indexOf(project) == 0 and project.length > cwd
-        cwd = project
+    cwd = utils.findRoot atom.workspace.getActiveTextEditor().getPath()
 
     settings = config.settings real_file
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,6 +11,7 @@ lint = require './lint'
 config = require './config'
 universalConfig = require './universal-config'
 autocomplete = require './autocomplete/autocomplete-clang'
+utils = require './utils'
 
 module.exports =
   provideBuilder: provideBuilder
@@ -44,6 +45,9 @@ module.exports =
       atom.commands.add 'atom-workspace',
         'PROS:Open-Cortex': => @openCortex()
 
+      atom.commands.add 'atom-workspace',
+        'PROS:Test': -> console.log utils.findRoot atom.workspace.getActiveTextEditor().getPath()
+
       cli.execute(((c, o) -> console.log o),
         cli.baseCommand().concat ['conduct', 'first-run', '--no-force', '--use-defaults'])
 
@@ -53,9 +57,8 @@ module.exports =
 
   uploadProject: ->
     if atom.project.getPaths().length > 0
-      cli.uploadInTerminal '-f "' + \
-        (atom.project.relativizePath(atom.workspace.getActiveTextEditor().getPath())[0] or \
-          atom.project.getPaths()[0]) + '"'
+      root = atom.workspace.getActiveTextEditor().getPath() or atom.project.getPaths()[0]
+      cli.uploadInTerminal '-f "' + utils.findRoot(root) + '"'
 
   newProject: ->
     @newProjectPanel.toggle()

--- a/lib/make.coffee
+++ b/lib/make.coffee
@@ -29,7 +29,7 @@ module.exports =
         return @files.length > 0
 
       settings: () ->
-        args = [ '-j' + config.settings('.').parallel_make_jobs or 2]
+        args = [ '-j' + config.settings('.').parallel_make_jobs or 1]
 
         if navigator.platform == 'Win32' and !!process.env['PROS_TOOLCHAIN'] and \
            process.env['PROS_TOOLCHAIN'] not in process.env['PATH']

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,0 +1,16 @@
+fs = require 'fs-plus'
+path = require 'path'
+
+module.exports =
+  findRoot: (_path, n = 10) ->
+    originalPath = _path
+    _path = fs.absolute _path
+    for x in [1...n] by 1
+      if _path and fs.existsSync(_path)
+        if fs.isDirectorySync(_path) and fs.existsSync(_path + "/project.pros")
+          return _path
+        else
+          _path = fs.absolute _path + '/..'
+      else
+        return atom.project.relativizePath(originalPath)[0] or originalPath
+    return atom.project.relativizePath(originalPath)[0] or originalPath

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "fs-extra": "^0.26.1",
     "split-string": "^0.1.0",
     "tempfile": "^1.1.0",
-    "voucher": "^0.1.2"
+    "voucher": "^0.1.2",
+    "fs-plus": "^2.9.0"
   },
   "package-deps": [
     "linter",


### PR DESCRIPTION
Anywhere where we need to find the root directory of a project should have more advanced logic for finding said directory. `findRoot` will search up 10 directories to try to find the `project.pros` file. If not found, then it will use the relative root directory as defined by Atom's Projects library or the path itself (if it couldn't get a project root path). This behavior is nearly identical to the behavior of the CLI.