### PR TITLE
Oct17 patch

### DIFF
--- a/lib/proscli.coffee
+++ b/lib/proscli.coffee
@@ -4,6 +4,7 @@ cp = require 'child_process'
 semver = require 'semver'
 statusbar = require './views/statusbar'
 {EOL} = require 'os'
+shell = require 'shell'
 brand = require './views/brand'
 {setTimeout} = require 'timers'
 
@@ -128,9 +129,14 @@ module.exports =
     @execute cmd: ['pros', 'upgrade', '--machine-output'], cb: (c, o, e) ->
       if c != 0
         atom.notifications.addError 'Unable to determine how PROS CLI is installed',
-            detail: 'You will need to upgrade PROS CLI for your intallation method.'
+            detail: 'You will need to upgrade PROS CLI manually.'
+            buttons: [
+              { className: 'btn btn-info', text: 'Open GitHub', onDidClick: -> shell.openExternal 'https://github.com/purduesigbots/pros/releases/latest' }
+            ]
       else
         cmd = o.split('\n').filter(Boolean).map Function.prototype.call, String.prototype.trim
+        if navigator.platform != "Win32" and cmd[0].endsWith "updater.exe"  # fix for frozen pacakging on alternative distributions
+          shell.openExternal "http://github.com/purduesigbots/pros-cli/releases/latest"
         if navigator.platform == "Win32" and cmd[0].endsWith "updater.exe"  # fix for calling upgrader on Windows
           cmd[1] = "/checknow"
           cmd[2] = "/reducedgui"

--- a/lib/views/new-project.coffee
+++ b/lib/views/new-project.coffee
@@ -1,7 +1,8 @@
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, Range} = require 'atom'
 {$, View, TextEditorView} = require 'atom-space-pen-views'
 fs = require 'fs'
 path = require 'path'
+os = require 'os'
 std = require './standard'
 {prosConduct} = cli = require '../proscli'
 
@@ -37,6 +38,10 @@ module.exports =
       @createButton.prop 'disabled', true
       @projectPathEditor.getModel().onDidChange =>
         @createButton.prop 'disabled', !!!@projectPathEditor.getText()
+
+      defaultPath = path.join path.dirname(atom.project.getPaths()[0]) or os.homedir(), 'pros-project'
+      @projectPathEditor.setText defaultPath
+      @projectPathEditor.getModel().setSelectedBufferRange [[0, defaultPath.length - 'pros-project'.length], [0, defaultPath.length]]
 
       @openDir.click => atom.pickFolder (paths) =>
         if paths?[0]

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "WelcomeView": "deserializeWelcomeView"
   },
   "cli_pros": {
-    "version": "2.6.0"
+    "version": "2.6.1"
   }
 }


### PR DESCRIPTION
- Bump to 2.6.1
  - Needed to make sure that most users are just directed to the download page
- Add default directory for new project modal (which is `~\pros-project`)